### PR TITLE
[feat] Docker container completed

### DIFF
--- a/shop-api/.mvn/wrapper/maven-wrapper.properties
+++ b/shop-api/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.1
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip

--- a/shop-api/Dockerfile
+++ b/shop-api/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application
+FROM eclipse-temurin:21 as build-env
+
+# Add metadata
+LABEL maintainer="srdjansvircevic@gmail.com"
+LABEL description="Docker image for building the application"
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the entire project into the container
+COPY . /app
+
+# Ensure Maven wrapper is executable
+RUN chmod +x ./mvnw
+
+# Build the project, skipping tests
+RUN ./mvnw clean install -Dmaven.test.skip
+
+# Stage 2: Create a minimal runtime image
+FROM eclipse-temurin:21-ubi9-minimal
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built jar from the build stage
+COPY --from=build-env /app/target/decem-0.0.1-SNAPSHOT.jar /app/
+
+# Expose the port your application runs on (optional)
+EXPOSE 8080
+
+# Specify the command to run your application
+ENTRYPOINT ["java", "-jar", "decem-0.0.1-SNAPSHOT.jar"]

--- a/shop-api/docker-compose.yml
+++ b/shop-api/docker-compose.yml
@@ -7,27 +7,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
-    # environment:
-    #   # Database configuration
-    #   - APP_DB_HOSTNAME=appdb
-    #   - APP_DB_USERNAME=spring
-    #   - APP_DB_PASSWORD=spring
-    #   - APP_DB_PORT=5432
-      
-    #   # Elasticsearch configuration
-    #   - ELASTICSEARCH_HOST=localhost
-    #   - ELASTICSEARCH_PORT=9200
-    #   - ELASTICSEARCH_SCHEME=http
-    #   - ELASTICSEARCH_USERNAME=elastic
-    #   - ELASTICSEARCH_PASSWORD=XH+Wn7ukSGKM+BfVfg3c
-      
-    #   # JWT configuration
-    #   - JWT_TOKEN_VALIDITY=18000
-    #   - JWT_SIGNING_KEY=signingkeytralalalasdfasdfewrgtrhgfshfdgajwherawehfksadasdgcvbnldsdfadsf
-    #   - JWT_AUTHORITIES_KEY=roles
-    #   - JWT_TOKEN_PREFIX=Bearer
-    #   - JWT_HEADER_STRING=Authorization
-
     depends_on:
       - appdb
 

--- a/shop-api/docker-compose.yml
+++ b/shop-api/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    # environment:
+    #   # Database configuration
+    #   - APP_DB_HOSTNAME=appdb
+    #   - APP_DB_USERNAME=spring
+    #   - APP_DB_PASSWORD=spring
+    #   - APP_DB_PORT=5432
+      
+    #   # Elasticsearch configuration
+    #   - ELASTICSEARCH_HOST=localhost
+    #   - ELASTICSEARCH_PORT=9200
+    #   - ELASTICSEARCH_SCHEME=http
+    #   - ELASTICSEARCH_USERNAME=elastic
+    #   - ELASTICSEARCH_PASSWORD=XH+Wn7ukSGKM+BfVfg3c
+      
+    #   # JWT configuration
+    #   - JWT_TOKEN_VALIDITY=18000
+    #   - JWT_SIGNING_KEY=signingkeytralalalasdfasdfewrgtrhgfshfdgajwherawehfksadasdgcvbnldsdfadsf
+    #   - JWT_AUTHORITIES_KEY=roles
+    #   - JWT_TOKEN_PREFIX=Bearer
+    #   - JWT_HEADER_STRING=Authorization
+
+    depends_on:
+      - appdb
+
+  appdb:
+    image: "postgres:15"
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=spring
+      - POSTGRES_PASSWORD=spring
+      - POSTGRES_DB=spring_shop2
+    volumes:
+      - ./appdb-data:/var/lib/postgresql/data


### PR DESCRIPTION
# Why

This PR was made to set up the initial configuration and deployment structure for the shop-api project. It includes necessary files for building, packaging, and running the application using Docker and Maven. The goal is to ensure a standardized environment for development and deployment.

# What

This PR introduces the following changes:

1. **Maven Wrapper Properties**:
    - Added `maven-wrapper.properties` file to specify the Maven wrapper version and distribution URL.
    ```diff
    +wrapperVersion=3.3.1
    +distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
    ```

2. **Dockerfile**:
    - Added a multi-stage Dockerfile to build the application using Eclipse Temurin JDK 21.
    - The first stage builds the application, skipping tests.
    - The second stage creates a minimal runtime image for the built application.
    ```diff
    +FROM eclipse-temurin:21 as build-env
    +LABEL maintainer="srdjansvircevic@gmail.com"
    +WORKDIR /app
    +COPY . /app
    +RUN chmod +x ./mvnw
    +RUN ./mvnw clean install -Dmaven.test.skip
    +
    +FROM eclipse-temurin:21-ubi9-minimal
    +WORKDIR /app
    +COPY --from=build-env /app/target/decem-0.0.1-SNAPSHOT.jar /app/
    +EXPOSE 8080
    +ENTRYPOINT ["java", "-jar", "decem-0.0.1-SNAPSHOT.jar"]
    ```

3. **Docker Compose Configuration**:
    - Added `docker-compose.yml` file to define the services required for running the application.
    - Configured `app` service to build from the Dockerfile and expose port 8080.
    - Added `appdb` service using the PostgreSQL image, with environment variables and volume configuration.
    ```diff
    +version: '3.8'
    +
    +services:
    +  app:
    +    build:
    +      context: .
    +      dockerfile: Dockerfile
    +    ports:
    +      - "8080:8080"
    +    depends_on:
    +      - appdb
    +
    +  appdb:
    +    image: "postgres:15"
    +    ports:
    +      - "5432:5432"
    +    environment:
    +      - POSTGRES_USER=spring
    +      - POSTGRES_PASSWORD=spring
    +      - POSTGRES_DB=spring_shop2
    +    volumes:
    +      - ./appdb-data:/var/lib/postgresql/data
    ```

# How to test

1. **Maven Build**:
    - Navigate to the project root directory.
    - Run `./mvnw clean install -Dmaven.test.skip` to ensure the project builds successfully using the Maven wrapper.

2. **Docker Build and Run**:
    - Ensure Docker is installed and running on your machine.
    - Run `docker-compose up --build` to build and start the services defined in `docker-compose.yml`.
    - Verify that the `app` service is running on port 8080 and the `appdb` service on port 5432.

3. **PostgreSQL Database**:
    - Check that the PostgreSQL container (`appdb`) is running by connecting to it using a PostgreSQL client with the credentials specified in the `docker-compose.yml` file.
    - Verify that the database `spring_shop2` is created and accessible.

---

This PR template clearly outlines the reasons for the changes, the specific modifications made, and the steps to test the implementation.